### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ To download the dataset, run the following command (if `debug = True`, only 5 ga
 python download.py --baseurls \
   https://alab.ise.ous.ac.jp/robocupdata/rc2024-roundrobin/ \
   https://alab.ise.ous.ac.jp/robocupdata/rc2021-roundrobin/ \
-  --subpaths normal/alice2021-helios2021 normal/alice2021-hfutengine202
+  --subpaths normal/alice2021-helios2021 normal/alice2021-hfutengine2021
 ```
-(Modified the code on Mar 31, 2025, to reduce server load& Dataset Links)
+(Modified the code on Feb 12, 2025, to reduce server load)
+(Modified the code on Mar 31, 2025, to modify dataset links)
 
 ### 2. Training, Testing, and Evaluation
 Run `main.py` for training, testing, and evaluation (you cannot run with fewer games in the current train/val/test splitting):

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ We provide a dataset generated using the RoboCup Soccer Simulator. This dataset 
 
 To download the dataset, run the following command (if `debug = True`, only 5 games for each url will be downloaded):  
 ```bash
-python download.py --subpaths rc2021-roundrobin/normal/alice2021-helios2021 rc2021-roundrobin/normal/alice2021-hfutengine2021
+python download.py --baseurls \
+  https://alab.ise.ous.ac.jp/robocupdata/rc2024-roundrobin/ \
+  https://alab.ise.ous.ac.jp/robocupdata/rc2021-roundrobin/ \
+  --subpaths normal/alice2021-helios2021 normal/alice2021-hfutengine202
 ```
-(Modified the code on Feb 12, 2025, to reduce server load)
+(Modified the code on Mar 31, 2025, to reduce server load& Dataset Links)
 
 ### 2. Training, Testing, and Evaluation
 Run `main.py` for training, testing, and evaluation (you cannot run with fewer games in the current train/val/test splitting):


### PR DESCRIPTION
This commit modifies the download.py script so that it now accepts and processes data from both the 2024 and 2021 round-robin directories. 

Previously, the script was only configured to work with a single base directory, which limited its utility when different data years were needed. By combining subpaths from:
  - https://alab.ise.ous.ac.jp/robocupdata/rc2024-roundrobin/
  - https://alab.ise.ous.ac.jp/robocupdata/rc2021-roundrobin/

we ensure that users can download data from both years with a single command. This update improves the flexibility of our data acquisition process and supports comparative analyses across different seasons.

Users can now invoke the script with a unified command, such as:

   python download.py --baseurls \
  https://alab.ise.ous.ac.jp/robocupdata/rc2024-roundrobin/ \
  https://alab.ise.ous.ac.jp/robocupdata/rc2021-roundrobin/ \
  --subpaths normal/alice2021-helios2021 normal/alice2021-hfutengine2021


This change is part of our ongoing effort to standardize data access and make the project more versatile for researchers comparing multi-year datasets.